### PR TITLE
Make packaging resilient and non-publishing

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,15 +1,40 @@
-name: Build Release Artifacts
+name: Validate and Build Artifacts
 
 on:
+  pull_request:
   push:
     branches: [main]
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check release workflow contract
+        run: npm run check:release-workflow
+
+      - name: Build frontend
+        run: npm run build
+
   build-windows:
+    needs: validate
+    if: github.event_name != 'pull_request'
     runs-on: windows-latest
 
     steps:
@@ -36,83 +61,97 @@ jobs:
       - name: Build Tauri app
         run: npm run tauri build -- --no-bundle
 
-      - name: Install Enigma Virtual Box
+      - name: Create standard Windows artifact
         shell: pwsh
         run: |
-          # Download EVB installer with multiple fallback sources
-          $evbUrls = @(
-            "https://www.enigmaprotector.com/assets/files/enigmavb.exe",
-            "https://enigmaprotector.com/assets/files/enigmavb.exe",
-            "https://web.archive.org/web/2024/https://enigmaprotector.com/assets/files/enigmavb.exe"
-          )
-          $evbInstaller = Join-Path $env:RUNNER_TEMP "enigmavb_setup.exe"
-          Remove-Item -Path $evbInstaller -Force -ErrorAction SilentlyContinue
+          $inputExe = Resolve-Path "src-tauri\target\release\tagmeister.exe"
+          $webviewDll = Get-ChildItem -Path "src-tauri\target" -Filter "WebView2Loader.dll" -Recurse | Select-Object -First 1
+          if (-not $webviewDll) {
+            throw "WebView2Loader.dll not found under src-tauri\\target"
+          }
+          $staging = Join-Path $PWD "windows-staging"
+          New-Item -ItemType Directory -Force -Path $staging | Out-Null
+          Copy-Item -Path $inputExe -Destination $staging -Force
+          Copy-Item -Path $webviewDll.FullName -Destination $staging -Force
+          Compress-Archive -Path "$staging\*" -DestinationPath "tagmeister-Windows.zip" -Force
+          $hash = (Get-FileHash "tagmeister-Windows.zip" -Algorithm SHA256).Hash.ToLowerInvariant()
+          [IO.File]::WriteAllText((Join-Path $PWD "tagmeister-Windows.zip.sha256"), "$hash  tagmeister-Windows.zip`n")
 
-          $downloaded = $false
-          foreach ($evbUrl in $evbUrls) {
-            Write-Host "Trying: $evbUrl"
-            for ($attempt = 1; $attempt -le 3; $attempt++) {
-              try {
-                # Use Invoke-WebRequest with browser-like headers
-                $headers = @{
-                  "User-Agent" = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-                  "Accept" = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
-                }
-                Invoke-WebRequest -Uri $evbUrl -OutFile $evbInstaller -UseBasicParsing -Headers $headers -MaximumRedirection 5
+      - name: Upload standard Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tagmeister-Windows
+          path: |
+            tagmeister-Windows.zip
+            tagmeister-Windows.zip.sha256
 
-                if ((Test-Path $evbInstaller) -and (Get-Item $evbInstaller).Length -gt 1MB) {
-                  $downloaded = $true
-                  Write-Host "Downloaded successfully from $evbUrl"
-                  break
-                }
-              } catch {
-                Write-Host "Attempt $attempt failed: $_"
-              }
-              Start-Sleep -Seconds 2
-            }
-            if ($downloaded) { break }
+      - name: Validate optional Enigma configuration
+        shell: pwsh
+        env:
+          ENIGMA_INSTALLER_URL: ${{ vars.ENIGMA_VIRTUAL_BOX_INSTALLER_URL }}
+          ENIGMA_INSTALLER_SHA256: ${{ vars.ENIGMA_VIRTUAL_BOX_INSTALLER_SHA256 }}
+        run: |
+          $hasUrl = -not [string]::IsNullOrWhiteSpace($env:ENIGMA_INSTALLER_URL)
+          $hasHash = -not [string]::IsNullOrWhiteSpace($env:ENIGMA_INSTALLER_SHA256)
+          if ($hasUrl -xor $hasHash) {
+            throw "Set both ENIGMA_VIRTUAL_BOX_INSTALLER_URL and ENIGMA_VIRTUAL_BOX_INSTALLER_SHA256, or neither"
+          }
+          if (-not $hasUrl) {
+            Write-Output "Optional Enigma packaging is not configured; the standard Windows artifact is available"
           }
 
-          if (-not $downloaded) {
-            throw "Failed to download EVB installer. The enigmaprotector.com site may be blocking CI downloads. Consider caching the installer in a GitHub release."
-          }
+  build-windows-portable:
+    needs: build-windows
+    if: github.event_name != 'pull_request' && vars.ENIGMA_VIRTUAL_BOX_INSTALLER_URL != '' && vars.ENIGMA_VIRTUAL_BOX_INSTALLER_SHA256 != ''
+    continue-on-error: true
+    runs-on: windows-latest
+    env:
+      ENIGMA_INSTALLER_URL: ${{ vars.ENIGMA_VIRTUAL_BOX_INSTALLER_URL }}
+      ENIGMA_INSTALLER_SHA256: ${{ vars.ENIGMA_VIRTUAL_BOX_INSTALLER_SHA256 }}
 
-          # Install silently
-          $process = Start-Process -FilePath $evbInstaller -ArgumentList "/VERYSILENT","/NORESTART" -Wait -PassThru
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download standard Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tagmeister-Windows
+
+      - name: Verify and install Enigma Virtual Box
+        shell: pwsh
+        run: |
+          if ($env:ENIGMA_INSTALLER_SHA256 -notmatch '^[a-fA-F0-9]{64}$') {
+            throw "ENIGMA_VIRTUAL_BOX_INSTALLER_SHA256 must be a 64-character SHA-256 value"
+          }
+          $installer = Join-Path $env:RUNNER_TEMP "enigmavb_setup.exe"
+          Invoke-WebRequest -Uri $env:ENIGMA_INSTALLER_URL -OutFile $installer -MaximumRedirection 5
+          $actualHash = (Get-FileHash $installer -Algorithm SHA256).Hash
+          if (-not $actualHash.Equals($env:ENIGMA_INSTALLER_SHA256, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Enigma Virtual Box installer SHA-256 mismatch"
+          }
+          $process = Start-Process -FilePath $installer -ArgumentList "/VERYSILENT","/NORESTART" -Wait -PassThru
           if ($process.ExitCode -ne 0) {
             throw "EVB installer failed with exit code $($process.ExitCode)"
-          }
-
-          # Verify
-          if (Test-Path "C:\Program Files (x86)\Enigma Virtual Box\enigmavbconsole.exe") {
-            Write-Host "EVB installed successfully"
-          } else {
-            throw "EVB installation failed"
           }
 
       - name: Create portable exe
         shell: pwsh
         run: |
-          # Install @insco/enigma-virtualbox CLI globally
-          npm install -g @insco/enigma-virtualbox
-          if ($LASTEXITCODE -ne 0) {
-            throw "Failed to install @insco/enigma-virtualbox"
-          }
-
-          $inputExe = Resolve-Path "src-tauri\target\release\tagmeister.exe"
-          $outputExe = Join-Path $PWD "src-tauri\target\release\tagmeister-Portable.exe"
-          $webviewDll = Get-ChildItem -Path "src-tauri\target" -Filter "WebView2Loader.dll" -Recurse | Select-Object -First 1
-          if (-not $webviewDll) {
-            throw "WebView2Loader.dll not found under src-tauri\\target"
-          }
-          $webviewDllPath = $webviewDll.FullName
-
-          # Use enigmavirtualbox to generate a compatible EVB project file
-          $evbStaging = Join-Path $PWD "evb-staging"
-          New-Item -ItemType Directory -Force -Path $evbStaging | Out-Null
-          Copy-Item -Path $webviewDllPath -Destination $evbStaging -Force
+          Expand-Archive -Path "tagmeister-Windows.zip" -DestinationPath "windows-staging" -Force
+          $inputExe = Resolve-Path "windows-staging\tagmeister.exe"
+          $outputExe = Join-Path $PWD "tagmeister-Portable.exe"
           $evbProject = Join-Path $PWD "tagmeister.evb"
-          enigmavirtualbox generate $evbStaging --input $inputExe --output $outputExe --project-name $evbProject
+          & ".\node_modules\.bin\enigmavirtualbox.cmd" generate "windows-staging" --input $inputExe --output $outputExe --project-name $evbProject
           if ($LASTEXITCODE -ne 0) {
             throw "enigmavirtualbox generate failed"
           }
@@ -121,47 +160,19 @@ jobs:
             throw "enigmavbconsole.exe not found at $evbConsole"
           }
           & $evbConsole $evbProject
-          if ($LASTEXITCODE -ne 0) {
-            throw "enigmavbconsole failed"
+          if ($LASTEXITCODE -ne 0 -or -not (Test-Path $outputExe)) {
+            throw "Enigma Virtual Box portable build failed"
           }
 
-          # Verify output
-          if (Test-Path $outputExe) {
-            $size = [math]::Round((Get-Item $outputExe).Length / 1MB, 2)
-            Write-Host "Portable exe created: $size MB"
-          } else {
-            throw "Failed to create portable exe"
-          }
-
-      - name: Upload portable exe
+      - name: Upload portable Windows artifact
         uses: actions/upload-artifact@v4
         with:
           name: tagmeister-Portable
-          path: src-tauri/target/release/tagmeister-Portable.exe
-
-      - name: Determine release tag
-        id: release_tag
-        if: github.ref == 'refs/heads/main'
-        shell: pwsh
-        run: |
-          $version = (Get-Content package.json | ConvertFrom-Json).version
-          if (-not $version) {
-            throw "package.json version not found"
-          }
-          "version=$version" >> $env:GITHUB_OUTPUT
-          "tag=v$version" >> $env:GITHUB_OUTPUT
-
-      - name: Create or update GitHub release
-        if: github.ref == 'refs/heads/main'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.release_tag.outputs.tag }}
-          target_commitish: ${{ github.sha }}
-          generate_release_notes: true
-          files: src-tauri/target/release/tagmeister-Portable.exe
+          path: tagmeister-Portable.exe
 
   build-macos:
-    needs: build-windows
+    needs: validate
+    if: github.event_name != 'pull_request'
     runs-on: macos-latest
 
     steps:
@@ -236,22 +247,3 @@ jobs:
         with:
           name: tagmeister-macOS-dmg
           path: src-tauri/target/release/bundle/dmg/*.dmg
-
-      - name: Determine release tag
-        id: release_tag
-        if: github.ref == 'refs/heads/main'
-        run: |
-          version=$(node -p "require('./package.json').version")
-          if [ -z "$version" ]; then
-            echo "package.json version not found"
-            exit 1
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=v$version" >> "$GITHUB_OUTPUT"
-
-      - name: Upload dmg to GitHub release
-        if: github.ref == 'refs/heads/main'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.release_tag.outputs.tag }}
-          files: src-tauri/target/release/bundle/dmg/*.dmg

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ npm run tauri build
 
 Run `npm run tauri build` locally whenever you want to publish a new version; all releases are produced manually from a development machine.
 
+CI validates pull requests and uploads non-publishing Windows and macOS artifacts from `main`. The optional packed Windows executable requires both `ENIGMA_VIRTUAL_BOX_INSTALLER_URL` and `ENIGMA_VIRTUAL_BOX_INSTALLER_SHA256` repository variables; the standard Windows ZIP remains available when they are unset or optional packaging fails.
+
 ## Usage
 
 1. Click the folder icon to select an image directory

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "zustand": "^5.0.3"
       },
       "devDependencies": {
+        "@insco/enigma-virtualbox": "1.3.4",
         "@tauri-apps/cli": "^2",
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.1",
@@ -352,6 +353,29 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
       "license": "MIT"
+    },
+    "node_modules/@insco/enigma-virtualbox": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@insco/enigma-virtualbox/-/enigma-virtualbox-1.3.4.tgz",
+      "integrity": "sha512-OjzeaJwslIg4LeRN4H+YYGTM9kYhdHlcmg0HR7/CI8/ms18pPq/Sty/KDR9AbBg8KKmOfJfNxRVjMgtJGfxQXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "chalk": "^5.6.0",
+        "consola": "^3.4.2",
+        "handlebars": "^4.7.8",
+        "lodash-es": "^4.17.21",
+        "minimatch": "^9.0.5"
+      },
+      "bin": {
+        "enigmavirtualbox": "bin/virtualbox.js",
+        "evb": "bin/virtualbox.js",
+        "virtualbox": "bin/virtualbox.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -1316,6 +1340,33 @@
         "npm": ">=6"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1338,6 +1389,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -1357,6 +1421,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/convert-source-map": {
@@ -1693,6 +1767,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/has-symbols": {
@@ -2090,6 +2196,13 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2132,6 +2245,32 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/motion-dom": {
       "version": "12.39.0",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.39.0.tgz",
@@ -2171,6 +2310,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -2538,6 +2684,20 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/vite": {
       "version": "8.0.16",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
@@ -2615,6 +2775,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zustand": {
       "version": "5.0.13",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --skipLibCheck && vite build",
+    "check:release-workflow": "node scripts/check-release-workflow.mjs",
     "preview": "vite preview",
     "tauri": "tauri"
   },
@@ -28,6 +29,7 @@
     "zustand": "^5.0.3"
   },
   "devDependencies": {
+    "@insco/enigma-virtualbox": "1.3.4",
     "@tauri-apps/cli": "^2",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",

--- a/scripts/check-release-workflow.mjs
+++ b/scripts/check-release-workflow.mjs
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+
+const workflow = readFileSync(new URL("../.github/workflows/build-release.yml", import.meta.url), "utf8");
+const required = [
+  "pull_request:",
+  "contents: read",
+  "ENIGMA_VIRTUAL_BOX_INSTALLER_URL",
+  "ENIGMA_VIRTUAL_BOX_INSTALLER_SHA256",
+  "tagmeister-Windows.zip",
+  "github.event_name != 'pull_request'",
+];
+const forbidden = [
+  "softprops/action-gh-release",
+  "tag_name:",
+  "enigmaprotector.com/assets/files/enigmavb.exe",
+];
+const errors = [
+  ...required.filter((value) => !workflow.includes(value)).map((value) => `missing ${value}`),
+  ...forbidden.filter((value) => workflow.includes(value)).map((value) => `forbidden ${value}`),
+];
+
+if (errors.length) {
+  throw new Error(`Release workflow contract failed:\n- ${errors.join("\n- ")}`);
+}
+
+console.log("Release workflow contract passed");


### PR DESCRIPTION
## Summary
- validate pull requests without running signing or publishing jobs
- upload a standard Windows ZIP and checksum independently of optional Enigma packaging
- require an operator-controlled Enigma installer URL and SHA-256, with a pinned project generator
- keep ordinary pushes read-only and remove automatic tag/release mutation

## Verification
- checksum-verified actionlint v1.7.12
- npm ci
- npm run check:release-workflow
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml
- npm run tauri build -- --no-bundle
- packaged executable startup smoke
- standard Windows ZIP/checksum and EVB project-generation smoke

The live EVB installer step remains skipped until both repository variables are configured; no tag or release action was performed.